### PR TITLE
Claim your fork

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
-# regexp-saver
+# regexp-saver-pro
 
 Visual Studio Code extension for saving and re-using regular expressions while coding.
+Forked from [phitranphitranphitran/regexp-saver](https://github.com/phitranphitranphitran/regexp-saver.git).
 
 ## Features
 

--- a/package.json
+++ b/package.json
@@ -153,7 +153,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/phitranphitranphitran/regexp-saver.git"
+    "url": "https://github.com/fjc0k/regexp-saver-pro.git"
   },
   "lint-staged": {
     "**/*": "prettier --write --ignore-unknown"


### PR DESCRIPTION
I really like [this extension](https://marketplace.visualstudio.com/items?itemName=JayFong.regexp-saver-pro), and I wanted to suggest to add a feature to it, but noticed the repo was pointing to an [abandoned repo](https://github.com/phitranphitranphitran/regexp-saver.git).

I noticed yours is the [only fork](https://github.com/phitranphitranphitran/regexp-saver/forks?include=active%2Carchived%2Cinactive&page=1&period=2y&sort_by=stargazer_counts), and it's creation date (2024-06-23) matches with the marketplace last update date. So I'm assuming this is the source repo.

I'm reaching out through here, because Issues and Discussions are disabled (default for GitHub forks).

First, I want to thank you for refreshing this extension.
I also wanted to ask whether you would be ok with maintaining it?

If so, please enable the Issues and discussions.
Feel free to accept this PR, as it will make it clear that this repo is a fork of original work done in the past.

Thanks in advance (whether you choose to maintain or not).